### PR TITLE
Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: ruby
+rvm: 2.4.2
+
+sudo: false
+cache: bundler
+
+env:
+  global:
+  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true  # speeds up installation of html-proofer
+
+script:
+- bundle exec jekyll build && bundle exec htmlproofer ./_site --check-html

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'github-pages', group: :jekyll_plugins
+gem 'html-proofer'

--- a/index.html
+++ b/index.html
@@ -1,7 +1,6 @@
 <html>
 <head>
   <title>GOCDB</title>
-  <link rel="stylesheet" type="text/css" href="home.css">
   <link rel="SHORTCUT ICON" href="https://github.com/GOCDB/gocdb/raw/master/htdocs/landing/egi_logo.jpg">
 </head>
 
@@ -10,8 +9,8 @@
     <div id="header">
       <h1>GOCDB</h1>
     </div>
-      <br></br>
-
+    <br>
+    <br>
     <div id="section">
       <p>Grid Operations Configuration Management Database. A Repository, Portal and REST style API for managing Grid and Cloud topology objects including; projects, administrative domains, sites, services,
           service-endpoints, service-groups, downtimes, users, roles and business rules. The View and Controller layers (i.e. the 'VC' in 'MVC') are inherited legacy from v4 and are scheduled to be re-implement
@@ -26,7 +25,8 @@
       </div>
     </div>
   </div>
-  <br></br>
+  <br>
+  <br>
   <div id="footer">
     <a href="http://www.stfc.ac.uk" target="_blank">
       <img src="STFC.jpg" height="25">

--- a/index.html
+++ b/index.html
@@ -29,13 +29,13 @@
   <br>
   <div id="footer">
     <a href="http://www.stfc.ac.uk" target="_blank">
-      <img src="STFC.jpg" height="25">
+      <img src="STFC.jpg" alt="STFC logo" height="25">
     </a>
     <a href="http://europa.eu" target="_blank">
-      <img src="eu.jpg" height="25">
+      <img src="eu.jpg" alt="EU logo" height="25">
     </a>
     <a href="http://www.egi.eu" target="_blank">
-      <img src="egi_logo.jpg" height="25">
+      <img src="egi_logo.jpg" alt="EGI logo" height="25">
     </a>
     GOCDB is an EGI service provided by
     <a class="Licence_Link" href="http://www.stfc.ac.uk/">STFC</a>


### PR DESCRIPTION
This PR adds automated GitHub Pages testing with Travis and also makes use of the new Travis GitHub Apps integration on travis-ci.com.

Also fixes a few HTML problems:
- Unused `css` tag (the style is included in the HTML)
- Bad `br` tags
- Missing alt text on images