### PR TITLE
Clean up of old content, add reserved scope documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,14 +160,18 @@
 </html>
 
 <style>
-  p {
-    padding-left: 35px;
-    padding-right: 35px;
+  p, h2, h3, h4 {
+    margin-left: 35px;
+    margin-right: 35px;
+  }
+
+  ul {
+    margin-left: 20px;
+    margin-right: 20px;
   }
 
   #page {
     background-color: aliceblue;
-    height: 100%;
     background: -webkit-linear-gradient(aliceblue, #A0DDEB);
     background: -o-linear-gradient(aliceblue, #A0DDEB);
     background: -moz-linear-gradient(aliceblue, #A0DDEB);

--- a/index.html
+++ b/index.html
@@ -15,6 +15,126 @@
           service-endpoints, service-groups, downtimes, users, roles and
           business rules.
         </p>
+        <section id="Documentation">
+        <h2>
+          Documentation
+        </h2>
+        <h3>
+          <section id="Reserved Scope Tags">
+          Reserved Scope Tags
+        </h3>
+        <ul>
+          <li>
+            Some tags may be 'Reserved' which means they are protected - they
+            are used to restrict tag usage and prevent non-authorised
+            sites/services from using tags not intended for them.
+          </li>
+          <li>
+            Reserved tags are initially assigned to resources by the
+            gocdb-admins, and can then be optionally inherited by child
+            resources (tags can be initially assigned to NGIs, Sites,
+            Services and ServiceGroups).
+          </li>
+          <li>
+            When creating a new child resource (e.g. a child Site or child
+            Service), the scopes that are assigned to the parent are
+            automatically inherited and assigned to the child.
+          </li>
+          <li>
+            Reserved tags assigned to a resource are optional and can be
+            de-selected if required.
+          </li>
+          <li>
+            Users can reapply Reserved tags to a resource ONLY if the tag
+            can be inherited from the parent Scoped Entity
+            (parents include NGIs/Sites).
+            <ul>
+              <li>
+                For Sites: If a Reserved tag is removed from a Site, then
+                the same tag is also removed from all the child Services - a
+                Service can't have a reserved tag that is not supported by
+                its parent Site.
+              </li>
+              <li>
+                For NGIs: If a Reserved tag is removed from an NGI, then the
+                same tag is NOT removed from all the child Sites - this is
+                intentionally different from the Site->Service relationship.
+              </li>
+            </ul>
+          </li>
+          <li>
+            To request a reserved scope tag, an approval is required from the
+            operators of the relevant resources. Details on who to contact
+            are listed below. Once authorisation is given, please contact
+            the GOCDB admins with details of the approval (e.g. link to a
+            GGUS ticket that approves the tag assignment).
+          </li>
+        </ul>
+        <h4>
+          <section id="FedCloud Reserved Tag">
+          FedCloud Reserved Tag
+        </h4>
+        <p>
+          Tag for resources that contribute to the EGI Federated Cloud. To
+          request this tag, please contact the FedCloud operators /
+          EGI Operations.
+        </p>
+        <h4>
+          <section id="Elixir Reserved Tag">
+          Elixir Reserved Tag
+        </h4>
+        <p>
+          Tag for resources that contribute to the EGI Federated Cloud. To
+          request this tag, please contact the operators of the ‘ELIXIR’ NGI
+          in GOCDB.
+        </p>
+        <h4>
+          <section id="WLCG Reserved Tags">
+          WLCG Reserved Tags
+        </h4>
+        <p>
+          A number of reserved scope tags have been defined for the WLCG:
+          <ul>
+            <li>
+              The ‘tierN’ tags should be requested for WLCG sites that are
+              defined in REBUS (a management view of the WLCG
+              infrastructure/sites). To request a ‘tierN’ tag, raise a ticket
+              against the REBUS support unit in GGUS.
+            </li>
+            <li>
+              For the experiment VO tags (alice, atlas, cms, lhcb), raise a
+              ticket with the relevant VO support unit.
+            </li>
+            <li>
+              The wlcg tag is a generic catch-all tag for sites/services with
+              either tierN and VO tags and is used to gain an overall view of
+              the WLCG infrastructure.
+            </li>
+          </ul>
+        </p>
+        <h4>
+          <section id="SLA Reserved Tag">
+          SLA Reserved Tag
+        </h4>
+        <p>
+          Entitities covered by an EGI VO SLA. This Tag will only be applied
+          at the request of EGI operations
+        </p>
+        <h4>
+          <section id="EOSCCore Tag">
+          EOSCCore Tag
+        </h4>
+        <p>
+          Tag for resources that contribute to core services of the EOSC. To request this tag, please raise a GGUS ticket against the Operations SU.
+        </p>
+        <h4>
+          <section id="EGICore Tag">
+          EGICore Tag
+        </h4>
+        <p>
+          Tag for resources that are part of the EGI Core services. To request this tag, please raise a GGUS ticket against the Operations SU.
+        </p>
+
     <div id="footer">
       <a href="http://www.stfc.ac.uk" target="_blank">
         <img src="STFC.jpg" alt="STFC logo" height="25">

--- a/index.html
+++ b/index.html
@@ -1,143 +1,126 @@
 <html>
-<head>
-  <title>GOCDB</title>
-  <link rel="SHORTCUT ICON" href="https://github.com/GOCDB/gocdb/raw/master/htdocs/landing/egi_logo.jpg">
-</head>
+  <head>
+    <title>GOCDB</title>
+  </head>
 
-<body>
-  <div id="page">
-    <div id="header">
-      <h1>GOCDB</h1>
-    </div>
-    <br>
-    <br>
-    <div id="section">
-      <p>Grid Operations Configuration Management Database. A Repository, Portal and REST style API for managing Grid and Cloud topology objects including; projects, administrative domains, sites, services,
-          service-endpoints, service-groups, downtimes, users, roles and business rules. The View and Controller layers (i.e. the 'VC' in 'MVC') are inherited legacy from v4 and are scheduled to be re-implement
-          using a modern MVC framework.</p>
-      <div id="dropdown">
-        <button id="dropbtn">Documentation</button>
-      <div id="dropdown-content">
-        <a href="https://wiki.egi.eu/w/images/d/d3/GOCDB5_Grid_Topology_Information_System.pdf" target="_blank">GOCDB Executive Summary</a>
-        <a href="https://wiki.egi.eu/wiki/GOCDB" target="_blank">EGI GOCDB wiki landing page</a>
-        <a href="https://wiki.egi.eu/wiki/GOCDB_Documentation_Index" target="_blank">GOCDB Documentation index</a>
-        <a href="https://wiki.egi.eu/wiki/GOCDB/Input_System_User_Documentation" target="_blank">User docs</a>
+  <body>
+    <div id="page">
+      <div id="header">
+        <h1>GOCDB</h1>
+      </div>
+        <p>
+          Grid Operations Configuration Management Database. A Repository,
+          Portal and REST style API for managing Grid and Cloud topology
+          objects including; projects, administrative domains, sites, services,
+          service-endpoints, service-groups, downtimes, users, roles and
+          business rules.
+        </p>
+    <div id="footer">
+      <a href="http://www.stfc.ac.uk" target="_blank">
+        <img src="STFC.jpg" alt="STFC logo" height="25">
+      </a>
+      <a href="http://europa.eu" target="_blank">
+        <img src="eu.jpg" alt="EU logo" height="25">
+      </a>
+      <a href="http://www.egi.eu" target="_blank">
+        <img src="egi_logo.jpg" alt="EGI logo" height="25">
+      </a>
+      GOCDB is an EGI service provided by
+      <a class="Licence_Link" href="http://www.stfc.ac.uk/">STFC</a>
+      , co-funded by
+      <a class="Licence_Link" href="http://www.egi.eu">EGI.eu</a>
+      and
+      <a href="http://go.egi.eu/eng">EGI-Engage</a>
+      . Licensed under the
+      <a class="Licence_Link" href="http://www.apache.org/licenses/LICENSE-2.0">Apache 2 License</a>
+      .
       </div>
     </div>
-  </div>
-  <br>
-  <br>
-  <div id="footer">
-    <a href="http://www.stfc.ac.uk" target="_blank">
-      <img src="STFC.jpg" alt="STFC logo" height="25">
-    </a>
-    <a href="http://europa.eu" target="_blank">
-      <img src="eu.jpg" alt="EU logo" height="25">
-    </a>
-    <a href="http://www.egi.eu" target="_blank">
-      <img src="egi_logo.jpg" alt="EGI logo" height="25">
-    </a>
-    GOCDB is an EGI service provided by
-    <a class="Licence_Link" href="http://www.stfc.ac.uk/">STFC</a>
-    , co-funded by
-    <a class="Licence_Link" href="http://www.egi.eu">EGI.eu</a>
-    and
-    <a href="http://go.egi.eu/eng">EGI-Engage</a>
-    . Licensed under the
-    <a class="Licence_Link" href="http://www.apache.org/licenses/LICENSE-2.0">Apache 2 License</a>
-    .
-    </div>
-  </div>
-
-
-</body>
-
+  </body>
 </html>
 
 <style>
-#page {
-  background-color: aliceblue;
-  height: 100%;
-  background: -webkit-linear-gradient(aliceblue, #A0DDEB);
-  background: -o-linear-gradient(aliceblue, #A0DDEB);
-  background: -moz-linear-gradient(aliceblue, #A0DDEB);
-}
-
-#header {
-  font-family: "Avant Garde", Avantgarde, "Century Gothic", CenturyGothic, "AppleGothic", sans-serif;
-  font-size: 40px;
-  padding: 40px 25px;
-  text-align: center;
-  text-transform: uppercase;
-  text-rendering: optimizeLegibility;
-  color: #131313;
-  letter-spacing: .15em;
-
-}
-
-
-
-#dropbtn {
-    background-color: #0D728E;
-    color: white;
-    padding: 16px;
-    font-size: 16px;
-    border: none;
-    cursor: pointer;
-}
-
-#dropdown {
-    position: relative;
-    display: inline-block;
-}
-
-#dropdown-content {
-    display: none;
-    position: absolute;
+  #page {
     background-color: aliceblue;
-    min-width: 160px;
-    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
-}
+    height: 100%;
+    background: -webkit-linear-gradient(aliceblue, #A0DDEB);
+    background: -o-linear-gradient(aliceblue, #A0DDEB);
+    background: -moz-linear-gradient(aliceblue, #A0DDEB);
+  }
 
-#dropdown-content a {
-    color: black;
-    padding: 12px 16px;
-    text-decoration: none;
-    display: block;
-}
+  #header {
+    font-family: "Avant Garde", Avantgarde, "Century Gothic", CenturyGothic, "AppleGothic", sans-serif;
+    font-size: 40px;
+    padding: 40px 25px;
+    text-align: center;
+    text-transform: uppercase;
+    text-rendering: optimizeLegibility;
+    color: #131313;
+    letter-spacing: .15em;
 
-#dropdown-content a:hover {background-color: #f1f1f1}
+  }
 
-#dropdown:hover #dropdown-content {
-    display: block;
-}
+  #dropbtn {
+      background-color: #0D728E;
+      color: white;
+      padding: 16px;
+      font-size: 16px;
+      border: none;
+      cursor: pointer;
+  }
 
-#dropdown:hover #dropbtn {
-    background-color: lightblue;
-}
+  #dropdown {
+      position: relative;
+      display: inline-block;
+  }
 
+  #dropdown-content {
+      display: none;
+      position: absolute;
+      background-color: aliceblue;
+      min-width: 160px;
+      box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+  }
 
-#section {
-    width:page-width;
-    text-align:center;
-    margin-left: 450px;
-    margin-right: 450px;
-    padding:50px;
-    border:5px solid #0D728E;
-    background-color: aliceblue;
-    box-shadow: 10px 10px 5px grey;
-    border-radius: 25px;
-    font-family: sans-serif;
-}
-#footer {
-    border-top: 3px solid #0D728E;
-    border-bottom: 3px solid #0D728E;
-    margin-left: 450px;
-    margin-right: 450px;
-    color:black;
-    clear:both;
-    text-align:center;
-    padding:5px;
-    font-family: sans-serif;
-}
+  #dropdown-content a {
+      color: black;
+      padding: 12px 16px;
+      text-decoration: none;
+      display: block;
+  }
+
+  #dropdown-content a:hover {background-color: #f1f1f1}
+
+  #dropdown:hover #dropdown-content {
+      display: block;
+  }
+
+  #dropdown:hover #dropbtn {
+      background-color: lightblue;
+  }
+
+  #section {
+      width:page-width;
+      text-align:center;
+      margin-left: 450px;
+      margin-right: 450px;
+      padding:50px;
+      border:5px solid #0D728E;
+      background-color: aliceblue;
+      box-shadow: 10px 10px 5px grey;
+      border-radius: 25px;
+      font-family: sans-serif;
+  }
+
+  #footer {
+      border-top: 3px solid #0D728E;
+      border-bottom: 3px solid #0D728E;
+      margin-left: 450px;
+      margin-right: 450px;
+      color:black;
+      clear:both;
+      text-align:center;
+      padding:5px;
+      font-family: sans-serif;
+  }
 </style>

--- a/index.html
+++ b/index.html
@@ -40,6 +40,11 @@
 </html>
 
 <style>
+  p {
+    padding-left: 35px;
+    padding-right: 35px;
+  }
+
   #page {
     background-color: aliceblue;
     height: 100%;
@@ -51,13 +56,12 @@
   #header {
     font-family: "Avant Garde", Avantgarde, "Century Gothic", CenturyGothic, "AppleGothic", sans-serif;
     font-size: 40px;
-    padding: 40px 25px;
+    padding: 5px 5px;
     text-align: center;
     text-transform: uppercase;
     text-rendering: optimizeLegibility;
     color: #131313;
     letter-spacing: .15em;
-
   }
 
   #dropbtn {


### PR DESCRIPTION
Given that the EGI Wiki is deprecated, I'd like to start making use of [GOCDB.github.io](https://github.com/GOCDB/GOCDB.github.io) for documentation relevant to multiple GOCDB instances (i.e. goc.egi.eu, gocdb.iris.ac.uk and gocdb.eosc-portal.eu).

This is a very small first step.

I'm not sure how one can view the rendered HTML...