### PR TITLE
Update documented protection levels to reflect reality

### DIFF
--- a/api/read/get_cert_status_changes/index.md
+++ b/api/read/get_cert_status_changes/index.md
@@ -8,7 +8,7 @@
 
 | Description | Protection Level |
 | - | - |
-| Returns a list of changes/transitions to certification statuses. Note, if the requested Site certification status has never been updated from its initial state, then no changes will have occurred and the results will be empty.  | Protected (level 2) |
+| Returns a list of changes/transitions to certification statuses. Note, if the requested Site certification status has never been updated from its initial state, then no changes will have occurred and the results will be empty.  | Private (level 3) |
 
 ### Information
 

--- a/api/read/get_downtime_to_broadcast/index.md
+++ b/api/read/get_downtime_to_broadcast/index.md
@@ -8,7 +8,7 @@
 
 | Description | Protection Level |
 | - | - |
-| Returns the list of downtimes recently declared with notification settings | Protected (level 2) |
+| Returns the list of downtimes recently declared with notification settings | Public (level 1) |
 
 ### Information
 

--- a/api/read/get_ngi/index.md
+++ b/api/read/get_ngi/index.md
@@ -8,7 +8,7 @@
 
 | Description | Protection Level |
 | - | - |
-| Returns a list of NGIs with contact information | Protected (level 2) |
+| Returns a list of NGIs with contact information | Private (level 3) |
 
 ### Information
 

--- a/api/read/get_project_contacts/index.md
+++ b/api/read/get_project_contacts/index.md
@@ -8,7 +8,7 @@
 
 | Description | Protection Level |
 | - | - |
-| Returns a list of persons (and associated info) having a role over a project.  | Protected (level 2) |
+| Returns a list of persons (and associated info) having a role over a project.  | Private (level 3) |
 
 ### Information
 

--- a/api/read/get_roc_contacts/index.md
+++ b/api/read/get_roc_contacts/index.md
@@ -8,7 +8,7 @@
 
 | Description | Protection Level |
 | - | - |
-| Returns NGI contact details, including NGI contact mail address and list of NGI staff  | Protected (level 2) |
+| Returns NGI contact details, including NGI contact mail address and list of NGI staff  | Private (level 3) |
 
 ### Information
 

--- a/api/read/get_service_group/index.md
+++ b/api/read/get_service_group/index.md
@@ -8,7 +8,7 @@
 
 | Description | Protection Level |
 | - | - |
-| Returns a list of service groups and the service endpoints under those groups.  | Protected (level 2) |
+| Returns a list of service groups and the service endpoints under those groups.  | Private (level 3) |
 
 ### Information
 

--- a/api/read/get_service_group_role/index.md
+++ b/api/read/get_service_group_role/index.md
@@ -8,7 +8,7 @@
 
 | Description | Protection Level |
 | - | - |
-| Returns a list of service groups and the roles under those groups.  | Protected (level 2) |
+| Returns a list of service groups and the roles under those groups.  | Private (level 3) |
 
 ### Information
 

--- a/api/read/get_site/index.md
+++ b/api/read/get_site/index.md
@@ -10,7 +10,7 @@
 
 | Description | Protection Level |
 | - | - |
-| Returns site information including contacts, grouped by site | Protected (level 2) |
+| Returns site information including contacts, grouped by site | Private (level 3) |
 
 | Parameters | Effect | Format/Value(s) | Default | Example |
 | - | - | - | - | - |

--- a/api/read/get_site_security_info/index.md
+++ b/api/read/get_site_security_info/index.md
@@ -8,7 +8,7 @@
 
 | Description | Protection Level |
 | - | - |
-| Returns security/CSIRT contact information for sites | Protected (level 2) |
+| Returns security/CSIRT contact information for sites | Private (level 3) |
 
 ### Information
 

--- a/api/read/get_user/index.md
+++ b/api/read/get_user/index.md
@@ -8,7 +8,7 @@
 
 | Description | Protection Level |
 | - | - |
-| Returns a user or a list of users with associated details and roles. Note that roles apply to a particular project – this is shown in the XML which qualifies which user-roles apply to which project using the RECOGNISED_IN_PROJECTS element. | Protected (level 2) |
+| Returns a user or a list of users with associated details and roles. Note that roles apply to a particular project – this is shown in the XML which qualifies which user-roles apply to which project using the RECOGNISED_IN_PROJECTS element. | Private (level 3) |
 
 ### Information
 

--- a/api/read/index.md
+++ b/api/read/index.md
@@ -46,8 +46,8 @@ credential mechanism.
 
 | Method name | Description | Protection level |
 |-|-|-|
-[get_cert_status_changes](get_cert_status_changes/index.md) |Returns a list of changes to certification statuses | 2
-[get_cert_status_date](get_cert_status_date/index.md) | Returns a list of current certification statuses for Production sites and the date they entered that status | 3
+[get_cert_status_changes](get_cert_status_changes/index.md) |Returns a list of changes to certification statuses | 3
+[get_cert_status_date](get_cert_status_date/index.md) | Returns a list of current certification statuses for Production sites and the date they entered that status | 2
 [get_downtime](get_downtime/index.md) | Returns a list of service downtimes (downtimes are repeated for each affected service) | 1
 [get_downtime_nested_services](get_downtime_nested_services/index.md) | Returns a list of downtimes with affected services nested as child elements of the downtime | 1
 [get_downtime_to_broadcast](get_downtime_to_broadcast/index.md) | Returns the list of downtimes recently declared with notification settings for downtime notification services | 1


### PR DESCRIPTION
I assume the protection levels for `get_cert_status_changes` and `get_cert_status_date` got swapped in error due to the similar names.

It looks like most of this is due to bumping most level 2 methods to level 3 and indeed, these files were not updated in https://github.com/GOCDB/GOCDB.github.io/pull/15.

Interestingly, `get_downtime_to_broadcast` as documented gets knocked down to level 1. That is the level it is and, based on example output, should be.