### PR TITLE
Switch link checking to Linkspector

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,7 +36,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Check for broken links
-      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      uses: umbrelladocs/action-linkspector@v1
 
   spellcheck:
     name: Spellcheck


### PR DESCRIPTION
The previous action https://github.com/gaurav-nelson/github-action-markdown-link-check is deprecated and is no longer actively maintained as of Apr 2025

<img width="863" height="385" alt="image" src="https://github.com/user-attachments/assets/7e9492b0-9311-4bf1-945d-f6ac27e94837" />

Of the two suggested replacements (Linkspector and a fork of the original), Linkspector seems like the slightly more used one.